### PR TITLE
Add Google Translate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # fast-translator
+
+A small PySide6 application that floats above other windows and translates
+Spanish text into English using the Google Translate API.
+
+## Usage
+
+Run the translator with:
+
+```bash
+python floating_translator.py
+```
+
+The application contains a built-in example API key, but you can modify the
+`GOOGLE_API_KEY` constant in `floating_translator.py` to use your own.

--- a/floating_translator.py
+++ b/floating_translator.py
@@ -1,6 +1,11 @@
 # Floating Translator PySide6 GUI
 
 from PySide6 import QtCore, QtGui, QtWidgets
+import json
+from urllib import request, parse
+
+# User-provided Google API key for translation
+GOOGLE_API_KEY = "AIzaSyBQG_h_E_p9g7QvPpiiCt_qyiChmNNI6dE"
 
 class FloatingTranslatorWindow(QtWidgets.QWidget):
     def __init__(self):
@@ -118,14 +123,26 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         self.translated_label.setText(translated)
 
     def translate_text(self, text):
-        mapping = {
-            "Hola": "Hello",
-            "¿cómo estás?": "how are you?",
+        """Translate Spanish text to English using Google API."""
+        params = {
+            "q": text,
+            "target": "en",
+            "source": "es",
+            "format": "text",
+            "key": GOOGLE_API_KEY,
         }
-        result = text
-        for es, en in mapping.items():
-            result = result.replace(es, en)
-        return result
+        try:
+            data = parse.urlencode(params).encode()
+            req = request.Request(
+                "https://translation.googleapis.com/language/translate/v2",
+                data=data,
+            )
+            with request.urlopen(req) as resp:
+                payload = json.loads(resp.read().decode())
+                return payload["data"]["translations"][0]["translatedText"]
+        except Exception as exc:
+            print("Translation failed:", exc)
+            return text
 
     def copy_translation(self):
         clipboard = QtWidgets.QApplication.clipboard()


### PR DESCRIPTION
## Summary
- improve floating translator to use the Google Translate API
- document how to run the translator and customize the API key

## Testing
- `python -m py_compile floating_translator.py`

------
https://chatgpt.com/codex/tasks/task_e_6843375aa298832b9af3b05abdda3cae