### PR TITLE
Switch to Gemini for translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fast-translator
 
 A small PySide6 application that floats above other windows and translates
-Spanish text into English using the Google Translate API.
+Spanish text into English using Google's Gemini generative language API.
 
 ## Usage
 
@@ -12,4 +12,4 @@ python floating_translator.py
 ```
 
 The application contains a built-in example API key, but you can modify the
-`GOOGLE_API_KEY` constant in `floating_translator.py` to use your own.
+`GEMINI_API_KEY` constant in `floating_translator.py` to use your own.


### PR DESCRIPTION
## Summary
- replace Google Translate usage with Gemini API
- update README for new API

## Testing
- `python -m py_compile floating_translator.py`
- ❌ `from floating_translator import FloatingTranslatorWindow` *(failed: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68433924ecc4832b9e3b51c63bc36506