### PR TITLE
Update translator prompt and output filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ python floating_translator.py
 
 The application contains a built-in example API key, but you can modify the
 `GEMINI_API_KEY` constant in `floating_translator.py` to use your own.
+
+The translator prompts the Gemini API to respond with the English
+translation enclosed in double asterisks (for example `**hello**`).
+The application filters the response to display only the text inside the
+asterisks.

--- a/floating_translator.py
+++ b/floating_translator.py
@@ -2,6 +2,7 @@
 
 from PySide6 import QtCore, QtGui, QtWidgets
 import json
+import re
 from urllib import request
 
 # Optional fallback translator if Gemini filtering fails
@@ -147,7 +148,12 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
 
     def translate_text(self, text):
         """Translate Spanish text to English using Gemini."""
-        prompt = f"Translate the following Spanish text to English: {text}"
+        prompt = (
+            "Translate the following Spanish text to English as a single"
+            " concise phrase. Respond only with the English translation"
+            " wrapped in double asterisks.\n\nSpanish: "
+            f"{text}"
+        )
         payload = json.dumps(
             {"contents": [{"parts": [{"text": prompt}]}]}
         ).encode()
@@ -186,6 +192,12 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         line = text.strip().splitlines()[0]
         # Remove common bullet or formatting characters
         line = line.lstrip("*-• ").strip()
+
+        # Extract content wrapped in double asterisks if present
+        match = re.search(r"\*\*(.+?)\*\*", line)
+        if match:
+            return match.group(1).strip()
+
         if line.startswith("**") and line.endswith("**"):
             line = line[2:-2]
         line = line.strip("*")


### PR DESCRIPTION
## Summary
- instruct Gemini to return the translation surrounded by `**` markers
- filter out the text inside the markers when displaying the translation
- document the behaviour in the README

## Testing
- `python -m py_compile floating_translator.py`

------
https://chatgpt.com/codex/tasks/task_e_684370674d70832ba096ec5df4d4db63