### PR TITLE
Enable multiline input for translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ The translator prompts the Gemini API to respond with the English
 translation enclosed in double asterisks (for example `**hello**`).
 The application filters the response to display only the text inside the
 asterisks.
+
+Press `Ctrl+Enter` (or `Ctrl+Return`) inside the input box to send the text
+for translation. The input field supports multiple lines so you can type
+longer passages.

--- a/floating_translator.py
+++ b/floating_translator.py
@@ -74,6 +74,9 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         for lbl in (esp_label, arrow_label, eng_label):
             lbl.setStyleSheet("font-size: 14px; color: black;")
             lbl.setAlignment(QtCore.Qt.AlignCenter)
+            lbl.setSizePolicy(
+                QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed
+            )
         lang_row.addWidget(esp_label)
         lang_row.addSpacing(6)
         lang_row.addWidget(arrow_label)
@@ -94,12 +97,19 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         card_layout.setContentsMargins(16, 12, 16, 12)
         card_layout.setSpacing(8)
 
-        self.input_edit = QtWidgets.QLineEdit()
-        self.input_edit.setText("Hola, ¿cómo estás?")
-        # Only translate after the user presses Enter
-        self.input_edit.returnPressed.connect(self.translate_current_text)
+        self.input_edit = QtWidgets.QPlainTextEdit()
+        self.input_edit.setPlainText("Hola, ¿cómo estás?")
+        self.input_edit.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
+        )
+        shortcut = QtGui.QShortcut(
+            QtGui.QKeySequence("Ctrl+Return"), self.input_edit
+        )
+        shortcut.activated.connect(self.translate_current_text)
+        shortcut2 = QtGui.QShortcut(QtGui.QKeySequence("Ctrl+Enter"), self.input_edit)
+        shortcut2.activated.connect(self.translate_current_text)
         self.input_edit.setStyleSheet(
-            "QLineEdit {"
+            "QPlainTextEdit {"
             "color: black;"
             "font-weight: bold;"
             "border: none;"
@@ -112,6 +122,7 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         self.translated_label.setStyleSheet(
             "color: blue; font-size: 16px; font-weight: bold;"
         )
+        self.translated_label.setWordWrap(True)
         bottom_row = QtWidgets.QHBoxLayout()
         bottom_row.addWidget(self.translated_label)
         bottom_row.addStretch()
@@ -152,7 +163,7 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
 
     def translate_current_text(self):
         """Handle the Enter key press from the input box."""
-        self.on_text_changed(self.input_edit.text())
+        self.on_text_changed(self.input_edit.toPlainText())
 
     def translate_text(self, text):
         """Translate Spanish text to English using Gemini."""


### PR DESCRIPTION
## Summary
- switch input box to multiline `QPlainTextEdit`
- trigger translation with Ctrl+Enter
- keep language header from stretching
- allow translation label to wrap
- document new shortcut in README

## Testing
- `python -m py_compile floating_translator.py`
- `python floating_translator.py` *(fails: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6843748d34c4832b99b2c485e2162026