### PR TITLE
Adjust default floating window size

### DIFF
--- a/floating_translator.py
+++ b/floating_translator.py
@@ -22,8 +22,9 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
             QtCore.Qt.WindowStaysOnTopHint | QtCore.Qt.FramelessWindowHint,
         )
         self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
-        self.resize(380, 160)
-        self.setMinimumSize(300, 140)
+        # Start with a slightly larger window so multiple lines fit easily
+        self.resize(420, 200)
+        self.setMinimumSize(320, 160)
         self.offset = None
         self.init_ui()
 


### PR DESCRIPTION
## Summary
- tweak default window dimensions of the translator

## Testing
- `python -m py_compile floating_translator.py`


------
https://chatgpt.com/codex/tasks/task_e_684376fa9218832b876c709da3c0d5dc