### PR TITLE
Add rate limiting and translation cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ translation enclosed in double asterisks (for example `**hola**`).
 The application filters the response to display only the text inside the
 asterisks.
 
+Previous translations are stored in `translation_cache.json` so frequent
+requests are reused without contacting the API. A small delay is also applied
+between requests and the application automatically retries when the API
+responds with HTTP 429 errors.
+
 Press `Ctrl+Enter` (or `Ctrl+Return`) inside the input box to send the text
 for translation. The input field supports multiple lines so you can type
 longer passages.


### PR DESCRIPTION
## Summary
- throttle requests with a small delay and retry on HTTP 429
- cache translations in `translation_cache.json`
- document translation caching and rate limiting in README

## Testing
- `python -m py_compile floating_translator.py`
- `python floating_translator.py` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_684387ef0f98832b942a2903f8c3867c