### PR TITLE
Add translation history dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ responds with HTTP 429 errors.
 Press `Ctrl+Enter` (or `Ctrl+Return`) inside the input box to send the text
 for translation. The input field supports multiple lines so you can type
 longer passages.
+
+Click the small down-arrow button next to the copy icon to open the history
+menu. It lists previous translations ordered by how often each one has been
+used, showing a counter for every entry. Selecting an item copies the text to
+the clipboard and displays it again in the output label.


### PR DESCRIPTION
## Summary
- keep translation counts in cache
- add helper to get cached translations ordered by frequency
- show a history dropdown button to reuse past translations
- document new history menu

## Testing
- `python -m py_compile floating_translator.py`

------
https://chatgpt.com/codex/tasks/task_e_68438a5d121c832b86b8ea4378a68b89