### PR TITLE
Add API key settings popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Run the translator with:
 python floating_translator.py
 ```
 
-The application contains a built-in example API key, but you can modify the
-`GEMINI_API_KEY` constant in `floating_translator.py` to use your own.
+The application starts without an API key. Click the gear button in the bottom
+right corner to open the settings popup and enter your own key. The key is
+stored in `config.json` so you only need to provide it once.
 
 The translator prompts the Gemini API to respond with the target-language
 translation enclosed in double asterisks (for example `**hola**`).


### PR DESCRIPTION
## Summary
- load API key from `config.json`
- add `save_config` and `set_api_key` helpers
- add gear button next to the size grip that opens a settings popup
- settings popup lets users set the API key and links to Google AI Studio
- mention the gear button in the README

## Testing
- `python -m py_compile floating_translator.py`

------
https://chatgpt.com/codex/tasks/task_e_68439b0b6ea0832bbed69d86c8581b22