### PR TITLE
Improve threading and UI styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ translation enclosed in double asterisks (for example `**hola**`).
 The application filters the response to display only the text inside the
 asterisks.
 
+Translations are executed on a global `QThreadPool` so threads are reused
+between requests. This keeps the user interface responsive while avoiding the
+overhead of creating new threads for every translation.
+
 Previous translations are stored in `translation_cache.json` so frequent
 requests are reused without contacting the API. A small delay is also applied
 between requests and the application automatically retries when the API


### PR DESCRIPTION
## Summary
- use `QThreadPool` with `TranslationTask` for async translations
- tweak settings button styling
- color the API key link blue and small text
- document thread pool usage in README

## Testing
- `python -m py_compile floating_translator.py`
- `pip install PySide6`
- `python floating_translator.py` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68439d4a8f2c832bb8eff381cb1761d6