### PR TITLE
Improve UI customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ ellipsis to indicate activity.
 
 Press `Ctrl+Enter` (or `Ctrl+Return`) inside the input box to send the text
 for translation. The input field supports multiple lines so you can type
-longer passages.
+longer passages. Press `Ctrl+C` while editing to quickly copy the latest
+translation to the clipboard.
 
 Click the small down-arrow button next to the copy icon to open the history
 menu. It lists previous translations ordered by how often each one has been
@@ -52,3 +53,7 @@ the clipboard and displays it again in the output label. The menu also provides
 options to export the history to a text file or clear it entirely. The cache is
 automatically trimmed to the 15 most frequently used entries so it stays
 lightweight.
+
+The settings popup now includes options for dark mode and adjusting the font
+size. A blue minimize button next to the red close button lets you minimize the
+window when you want it out of the way.


### PR DESCRIPTION
## Summary
- allow dark mode and custom font size
- add minimize button, dark-mode toggle and font size controls
- change API key link color based on theme
- add Ctrl+C shortcut to copy latest translation
- document new customization options

## Testing
- `python -m py_compile floating_translator.py`


------
https://chatgpt.com/codex/tasks/task_e_6843ab2df728832b961febc3fd64f02e