### PR TITLE
Improve dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ options to export the history to a text file or clear it entirely. The cache is
 automatically trimmed to the 15 most frequently used entries so it stays
 lightweight.
 
-The settings popup now includes options for dark mode and adjusting the font
-size. A blue minimize button next to the red close button lets you minimize the
-window when you want it out of the way.
+The settings popup now includes a button for toggling dark mode as well as an
+option to adjust the font size. The button displays a moon when the interface
+is light and a sun when it is dark, switching the theme with a single click. A
+blue minimize button next to the red close button lets you minimize the window
+when you want it out of the way.

--- a/floating_translator.py
+++ b/floating_translator.py
@@ -623,10 +623,13 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         self.api_link.setStyleSheet("color: #2196F3;")
         layout.addWidget(self.api_link)
 
-        self.dark_checkbox = QtWidgets.QCheckBox("Modo oscuro")
-        self.dark_checkbox.setChecked(THEME == "dark")
-        self.dark_checkbox.stateChanged.connect(lambda _=None: self._on_theme_changed())
-        layout.addWidget(self.dark_checkbox)
+        self.theme_btn = QtWidgets.QPushButton()
+        self.theme_btn.setCheckable(True)
+        self.theme_btn.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
+        self.theme_btn.setChecked(THEME == "dark")
+        self.theme_btn.clicked.connect(lambda _=None: self._on_theme_changed())
+        layout.addWidget(self.theme_btn)
+        self._update_theme_button()
 
         font_row = QtWidgets.QHBoxLayout()
         font_row.addWidget(QtWidgets.QLabel("Tama\u00f1o fuente"))
@@ -638,9 +641,10 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         layout.addLayout(font_row)
 
     def _on_theme_changed(self) -> None:
-        self.dark_mode = self.dark_checkbox.isChecked()
+        self.dark_mode = self.theme_btn.isChecked()
         set_theme("dark" if self.dark_mode else "light")
         self.apply_theme()
+        self._update_theme_button()
 
     def _on_font_changed(self) -> None:
         self.font_size = self.font_spin.value()
@@ -680,9 +684,22 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         )
         self.api_link.setStyleSheet(f"color: {link_color};")
 
+    def _update_theme_button(self) -> None:
+        if self.theme_btn.isChecked():
+            self.theme_btn.setText("\u2600 Light mode")
+            self.theme_btn.setStyleSheet(
+                "QPushButton { background-color: white; color: black; border-radius: 16px; padding: 4px 8px; }"
+            )
+        else:
+            self.theme_btn.setText("\U0001F319 Dark mode")
+            self.theme_btn.setStyleSheet(
+                "QPushButton { background-color: #2196F3; color: white; border-radius: 16px; padding: 4px 8px; }"
+            )
+
     def show_settings(self):
         self.api_key_edit.setText(GEMINI_API_KEY)
-        self.dark_checkbox.setChecked(self.dark_mode)
+        self.theme_btn.setChecked(self.dark_mode)
+        self._update_theme_button()
         self.font_spin.setValue(self.font_size)
         self.settings_popup.adjustSize()
         pos = self.settings_btn.mapToGlobal(


### PR DESCRIPTION
## Summary
- replace the dark mode checkbox with a toggle button
- update README to mention new button

## Testing
- `python -m py_compile floating_translator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843acb396f4832bb60a19aa5feb34a7