### PR TITLE
Add language detection and new languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A small PySide6 application that floats above other windows and translates
 text between languages using Google's Gemini generative language API. Choose
-the source and target languages from the drop-down menus.
+the source and target languages from the drop-down menus. The source list now
+includes an "Detectar" option for automatic language detection and several
+additional languages such as Chinese, Japanese and Russian.
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PySide6
 googletrans==4.0.0rc1
+langdetect


### PR DESCRIPTION
## Summary
- extend `LANG_OPTIONS` and `LANG_PROMPT_NAMES` with additional languages
- support automatic source language detection using `langdetect`
- include "Detectar" option in the source language dropdown
- improve language swapping logic
- document new feature and update dependencies

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile floating_translator.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ae996744832b8c55588afacb7f69