### PR TITLE
Implement default target language with auto swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ the source and target languages from the drop-down menus. The source list now
 includes an "Detectar" option for automatic language detection and several
 additional languages such as Chinese, Japanese and Russian.
 
+When translating text the application automatically detects the input
+language. If the text is in the same language as the current target, the
+languages are swapped so the translation always goes to the opposite side.
+You can set a default language in the settings panel that will be used as the
+target whenever a new language is detected.
+
 ## Installation
 
 Install the required dependencies using pip:


### PR DESCRIPTION
## Summary
- let the app pick a default language to use when translating
- add a settings option to select the default language
- automatically swap languages if the input matches the current target
- document the new automatic switching behavior

## Testing
- `python -m py_compile floating_translator.py`
- `pip install -r requirements.txt` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6843b0352094832bb357dc89d6dc26d9