### PR TITLE
Add build batch for executable packaging

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,22 @@
+@echo off
+
+rem Build the Floating Translator executable
+
+rem Create virtual environment if it doesn't exist
+if not exist venv (
+    python -m venv venv
+)
+
+rem Activate the virtual environment
+call venv\Scripts\activate
+
+rem Ensure build dependencies
+pip install --upgrade pip
+pip install pyinstaller
+
+rem Package the application into a single executable with custom icon
+pyinstaller --noconsole --onefile --icon icon.ico floating_translator.py
+
+echo.
+echo Build complete. The executable can be found in the dist folder.
+


### PR DESCRIPTION
## Summary
- add `build.bat` to package the translator as an executable using PyInstaller

## Testing
- `python -m py_compile floating_translator.py`

------
https://chatgpt.com/codex/tasks/task_e_6843b4658ce8832b913cb337e640c7ea