### PR TITLE
Implement global hotkey for quick translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,9 @@ option to adjust the font size. The button displays a moon when the interface
 is light and a sun when it is dark, switching the theme with a single click. A
 blue minimize button next to the red close button lets you minimize the window
 when you want it out of the way.
+
+## Global hotkey
+
+Press `Ctrl+Shift+T` anywhere to translate the currently selected text. The
+application simulates a copy operation, grabs the clipboard contents and shows
+the English translation in the floating window.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PySide6
 googletrans==4.0.0rc1
 langdetect
+keyboard


### PR DESCRIPTION
## Summary
- add keyboard as a dependency
- implement `start_global_hotkey` to watch Ctrl+Shift+T
- add `handle_hotkey_text` method to process text from clipboard
- start the listener when launching the app
- document the new global hotkey in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile floating_translator.py`

------
https://chatgpt.com/codex/tasks/task_e_684b1db87560832ba88fe76017bcc9b3