### PR TITLE
Implement text replacement on global hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,6 @@ when you want it out of the way.
 ## Global hotkey
 
 Press `Ctrl+Shift+T` anywhere to translate the currently selected text. The
-application simulates a copy operation, grabs the clipboard contents and shows
-the English translation in the floating window.
+application copies the selection, sends it for translation and then pastes the
+result back so the highlighted text is replaced with its English equivalent.
+The translated phrase is also shown in the floating window.

--- a/floating_translator.py
+++ b/floating_translator.py
@@ -843,11 +843,20 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
 
     @QtCore.Slot(str)
     def handle_hotkey_text(self, text: str) -> None:
-        """Receive text from the global hotkey and translate it."""
+        """Display text grabbed by the global hotkey."""
         if not text:
             return
         self.input_edit.setPlainText(text)
-        self.translate_current_text()
+        self.show()
+        self.raise_()
+        self.activateWindow()
+
+    @QtCore.Slot(str)
+    def handle_hotkey_translation(self, text: str) -> None:
+        """Show a translation triggered by the global hotkey."""
+        if not text:
+            return
+        self.translated_label.setText(text)
         self.show()
         self.raise_()
         self.activateWindow()
@@ -965,7 +974,7 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
 
 
 def start_global_hotkey(window: "FloatingTranslatorWindow", hotkey: str = "ctrl+shift+t") -> None:
-    """Listen for ``hotkey`` globally and send the clipboard text to ``window``."""
+    """Listen for ``hotkey`` globally and translate the selected text."""
 
     def handle_hotkey() -> None:
         keyboard.press_and_release("ctrl+c")
@@ -977,6 +986,22 @@ def start_global_hotkey(window: "FloatingTranslatorWindow", hotkey: str = "ctrl+
             QtCore.Qt.QueuedConnection,
             QtCore.Q_ARG(str, text),
         )
+        if not text:
+            return
+        translated = translate_text(text, "auto", "en")
+        QtCore.QMetaObject.invokeMethod(
+            window,
+            "handle_hotkey_translation",
+            QtCore.Qt.QueuedConnection,
+            QtCore.Q_ARG(str, translated),
+        )
+        QtCore.QMetaObject.invokeMethod(
+            QtWidgets.QApplication.clipboard(),
+            "setText",
+            QtCore.Qt.QueuedConnection,
+            QtCore.Q_ARG(str, translated),
+        )
+        keyboard.press_and_release("ctrl+v")
 
     thread = threading.Thread(
         target=lambda: (keyboard.add_hotkey(hotkey, handle_hotkey), keyboard.wait()),


### PR DESCRIPTION
## Summary
- show copied text without translating on `handle_hotkey_text`
- add `handle_hotkey_translation` slot
- translate and paste text in `start_global_hotkey`
- document that Ctrl+Shift+T replaces the selected text

## Testing
- `python -m py_compile floating_translator.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684b254f604c832bafdd6bb1fce88a3a