### PR TITLE
Implement text replacement on global hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,6 @@ when you want it out of the way.
 ## Global hotkey
 
 Press `Ctrl+Shift+T` anywhere to translate the currently selected text. The
-application simulates a copy operation, grabs the clipboard contents and shows
-the English translation in the floating window.
+application copies the selection, sends it for translation and then pastes the
+result back so the highlighted text is replaced with its English equivalent.
+The translated phrase is also shown in the floating window.


### PR DESCRIPTION
## Summary
- show copied text without translating on `handle_hotkey_text`
- add `handle_hotkey_translation` slot
- translate and paste text in `start_global_hotkey`
- document that Ctrl+Shift+T replaces the selected text
- fix setting clipboard text via invokeMethod

## Testing
- `python -m py_compile floating_translator.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684b254f604c832bafdd6bb1fce88a3a