### PR TITLE
Fix Qt clipboard invokeMethod for global hotkey

### DIFF
--- a/floating_translator.py
+++ b/floating_translator.py
@@ -1000,6 +1000,7 @@ def start_global_hotkey(window: "FloatingTranslatorWindow", hotkey: str = "ctrl+
             "setText",
             QtCore.Qt.QueuedConnection,
             QtCore.Q_ARG(str, translated),
+            QtCore.Q_ARG(int, int(QtGui.QClipboard.Clipboard)),
         )
         keyboard.press_and_release("ctrl+v")
 


### PR DESCRIPTION
## Summary
- fix `QMetaObject::invokeMethod` call for setting clipboard text in `start_global_hotkey`

## Testing
- `python -m py_compile floating_translator.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684b2a9147e0832b9e1e67ba75f9140a