### PR TITLE
Fix clipboard argument type

### DIFF
--- a/floating_translator.py
+++ b/floating_translator.py
@@ -1000,7 +1000,6 @@ def start_global_hotkey(window: "FloatingTranslatorWindow", hotkey: str = "ctrl+
             "setText",
             QtCore.Qt.QueuedConnection,
             QtCore.Q_ARG(str, translated),
-            QtCore.Q_ARG(int, int(QtGui.QClipboard.Clipboard)),
         )
         keyboard.press_and_release("ctrl+v")
 


### PR DESCRIPTION
## Summary
- remove extra clipboard mode argument when setting clipboard text

## Testing
- `python -m py_compile floating_translator.py`


------
https://chatgpt.com/codex/tasks/task_e_684b2bbe5434832ba7cc068ff42bec45