### PR TITLE
Fix clipboard call through Qt meta-object

### DIFF
--- a/floating_translator.py
+++ b/floating_translator.py
@@ -1000,6 +1000,7 @@ def start_global_hotkey(window: "FloatingTranslatorWindow", hotkey: str = "ctrl+
             "setText",
             QtCore.Qt.QueuedConnection,
             QtCore.Q_ARG(str, translated),
+            QtCore.Q_ARG(QtGui.QClipboard.Mode, QtGui.QClipboard.Clipboard),
         )
         keyboard.press_and_release("ctrl+v")
 


### PR DESCRIPTION
## Summary
- call setText with clipboard mode to match Qt's signature

## Testing
- `python -m py_compile floating_translator.py`


------
https://chatgpt.com/codex/tasks/task_e_684b2f3f6c24832b91a8d35603a25a9e