### PR TITLE
Fix clipboard update timing for hotkey

### DIFF
--- a/floating_translator.py
+++ b/floating_translator.py
@@ -1003,7 +1003,7 @@ def start_global_hotkey(window: "FloatingTranslatorWindow", hotkey: str = "ctrl+
         QtCore.QMetaObject.invokeMethod(
             window,
             "set_clipboard_text",
-            QtCore.Qt.QueuedConnection,
+            QtCore.Qt.BlockingQueuedConnection,
             QtCore.Q_ARG(str, translated),
         )
         keyboard.press_and_release("ctrl+v")


### PR DESCRIPTION
## Summary
- ensure the clipboard update completes before pasting via the global hotkey

## Testing
- `python -m py_compile floating_translator.py`

------
https://chatgpt.com/codex/tasks/task_e_684b344992ac832ba9c5ccfa763ff74b