### PR TITLE
Fix pasting translation without stealing focus

### DIFF
--- a/floating_translator.py
+++ b/floating_translator.py
@@ -854,7 +854,6 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         self.input_edit.setPlainText(text)
         self.show()
         self.raise_()
-        self.activateWindow()
 
     @QtCore.Slot(str)
     def handle_hotkey_translation(self, text: str) -> None:
@@ -864,7 +863,6 @@ class FloatingTranslatorWindow(QtWidgets.QWidget):
         self.translated_label.setText(text)
         self.show()
         self.raise_()
-        self.activateWindow()
 
     def language_changed(self, *args):
         if not hasattr(self, "input_edit"):


### PR DESCRIPTION
## Summary
- keep focus on the original application when showing text from the hotkey

## Testing
- `python -m py_compile floating_translator.py`


------
https://chatgpt.com/codex/tasks/task_e_684b3681e058832bb4bd25cf579bfc5b