### PR TITLE
Avoid summarizing in Gemini translation prompt

### DIFF
--- a/floating_translator.py
+++ b/floating_translator.py
@@ -285,9 +285,9 @@ def translate_text(text: str, source_lang: str, target_lang: str) -> str:
     src_name = LANG_PROMPT_NAMES.get(source_lang, source_lang)
     tgt_name = LANG_PROMPT_NAMES.get(target_lang, target_lang)
     prompt = (
-        f"Translate the following {src_name} text to {tgt_name} as a single"
-        f" concise phrase. Respond only with the {tgt_name} translation"
-        f" wrapped in double asterisks.\n\n{src_name}: {text}"
+        f"Translate the following {src_name} text to {tgt_name} without"
+        f" summarizing or shortening it. Respond only with the {tgt_name}"
+        f" translation wrapped in double asterisks.\n\n{src_name}: {text}"
     )
     payload = json.dumps({"contents": [{"parts": [{"text": prompt}]}]}).encode()
     for attempt in range(3):


### PR DESCRIPTION
## Summary
- remove wording that encouraged short answers
- instruct Gemini to translate in full without summarizing

## Testing
- `python -m py_compile floating_translator.py`

------
https://chatgpt.com/codex/tasks/task_e_684b3e528034832bbd2cc355f65e0990